### PR TITLE
Correction closePopover example syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ var TestListPopover = React.createClass({
   showPopover: function() {
     this.setState({isVisible: true});
   },
-  closePopover() {
+  closePopover: function() {
     this.setState({isVisible: false});
   },
   setItem: function(item) {


### PR DESCRIPTION
In the example function(){ was left out for closePopover - changed function to be consistent with showPopover() & setItem() examples.
