### PR TITLE
Bump minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-list-popover",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "<ListPopover/> component to render a selectable list",
   "main": "ListPopover.js",
   "repository": {


### PR DESCRIPTION
I still get the version with the react-native dependency when installing from npm (which is broken). I think this will fix it?
