### PR TITLE
Fix "Invariant Violation: Objects are not valid as a React child"

### DIFF
--- a/ListPopover.js
+++ b/ListPopover.js
@@ -52,7 +52,7 @@ var ListPopover = React.createClass({
 
     var separator = <View style={separatorStyle}/>;
     if (rowData === this.props.list[0]) {
-      separator = {};
+      separator = null;
     }
 
     var row = <Text style={rowTextStyle}>{rowData}</Text>


### PR DESCRIPTION
The latest version of RN doesn't allow passing `{}` as a child of a JSX element and throws an error.
